### PR TITLE
タイムゾーン設定変更

### DIFF
--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,5 +1,5 @@
 FROM mysql:8.0
 
-ENV TZ=UTC
+ENV TZ=Asia/Tokyo
 
 COPY ./docker/mysql/my.cnf /etc/my.cnf

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.18-alpine
 
-ENV TZ=UTC
+ENV TZ=Asia/Tokyo
 
 # nginx config file
 COPY ./docker/nginx/*.conf /etc/nginx/conf.d/


### PR DESCRIPTION
- 現状DBに対して操作するとUTC基準となるため、タイムゾーン設定をAsia/Tokyoに変更
- nginxに関する設定は直接影響しないが、logなどに影響する恐れがあるため、合わせて変更